### PR TITLE
Fisrt working proposal for #2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
+##  Variables of role backuppc_client to configure a host to backup in a BackupPC server
 
-# The backuppc server we backup to. Normally installed with backuppc_server role
+# The backuppc server we backup to configuring it and fetching ssh key from. Normally installed with backuppc_server role
 backuppc_server_name: localhost
+# backuppc_server_name: backuppc.mydomain.org
 
-backup_state: present  #present/absent, to configure or erase client host configiguration in the server
+backup_state: present  #present/absent, to configure or erase client host configuration in the server
 
 # Flag that defines if the client host is configured or not 
 backuppc_client: true
@@ -22,9 +24,6 @@ backuppc_client_group: backuppc
 backuppc_local_fetch_dir: /var/lib/backuppc
 # The home dir of user backuppc which is used to perform backups in the server 
 backuppc_server_home: /var/lib/backuppc
-
-## backuppc server to configure and to fetch ssh key from (this variable is needed!!!)
-# backuppc_server_name: backuppc.mydomain.org
 
 backuppc_RsyncClientCmd: '$sshPath -x -q -l {{ backuppc_client_user }} $host sudo $rsyncPath $argList+'
 backuppc_RsyncClientRestoreCmd: '$sshPath -q -x -l {{ backuppc_client_user }} $host sudo $rsyncPath $argList+'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,10 @@
 # The backuppc server we backup to. Normally installed with backuppc_server role
 backuppc_server_name: localhost
 
-backup_state: present  #present/absent, to configure or erase client in the server
+backup_state: present  #present/absent, to configure or erase client host configiguration in the server
 
-backuppc_client: true # configure things in the client host 
+# Flag that defines if the client host is configured or not 
+backuppc_client: true
 
 # the folders that will be dumped to the backup
 include_files:
@@ -14,13 +15,19 @@ include_files:
   - /home
   - /root
 
-# The home dir of user backuppc which is used to perform backups in the client 
-backuppc_local_fetch_dir: /var/lib/backuppc  
+# Unix user used by the backuppc server to access to the client to backup it
+backuppc_client_user: backuppc
+backuppc_client_group: backuppc
+# The home dir of user backuppc which is used to perform backups in the client
+backuppc_local_fetch_dir: /var/lib/backuppc
 # The home dir of user backuppc which is used to perform backups in the server 
 backuppc_server_home: /var/lib/backuppc
 
-## backuppc server to configure and to fetch ssh key from
+## backuppc server to configure and to fetch ssh key from (this variable is needed!!!)
 # backuppc_server_name: backuppc.mydomain.org
+
+backuppc_RsyncClientCmd: '$sshPath -x -q -l {{ backuppc_client_user }} $host sudo $rsyncPath $argList+'
+backuppc_RsyncClientRestoreCmd: '$sshPath -q -x -l {{ backuppc_client_user }} $host sudo $rsyncPath $argList+'
 
 # Flag to install the scripts pre_dump.sh and post_dump.sh
 backuppc_scripts: false
@@ -30,14 +37,14 @@ backuppc_scripts_sudo: false
 
 # The ssh command for backuppc to execute the pre_dump and post_dump scripts
 backuppc_DumpPreUserCmd: '{% if backuppc_scripts_sudo is defined and backuppc_scripts_sudo
-                       %}$sshPath -q -x -l backuppc $host sudo {{ backuppc_local_fetch_dir }}/scripts/pre_dump.sh{%
+                       %}$sshPath -q -x -l {{ backuppc_client_user }} $host sudo {{ backuppc_local_fetch_dir }}/scripts/pre_dump.sh{%
                     else
-                       %}$sshPath -q -x -l backuppc $host {{ backuppc_local_fetch_dir }}/scripts/pre_dump.sh{%
+                       %}$sshPath -q -x -l {{ backuppc_client_user }} $host {{ backuppc_local_fetch_dir }}/scripts/pre_dump.sh{%
                     endif %}'
 backuppc_DumpPostUserCmd: '{% if backuppc_scripts_sudo is defined and backuppc_scripts_sudo
-                       %}$sshPath -q -x -l backuppc $host sudo {{ backuppc_local_fetch_dir }}/scripts/post_dump.sh{%
+                       %}$sshPath -q -x -l {{ backuppc_client_user }} $host sudo {{ backuppc_local_fetch_dir }}/scripts/post_dump.sh{%
                     else
-                       %}$sshPath -q -x -l backuppc $host {{ backuppc_local_fetch_dir }}/scripts/post_dump.sh{%
+                       %}$sshPath -q -x -l {{ backuppc_client_user }} $host {{ backuppc_local_fetch_dir }}/scripts/post_dump.sh{%
                     endif %}'
 
 # The commands authorized in the client to the user backuppc. This variable _must_ start with "Cmnd_Alias BACKUPS"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
 
 - name: restart backuppc
-  action: service name=backuppc state=restarted enabled=yes
+  service: 
+    name: backuppc
+    state: restarted
+    enabled: yes
   delegate_to: "{{ backuppc_server_name }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -13,7 +13,9 @@
   notify: restart backuppc
 
 - name: FILE | Delete config if needed
-  file: path='/etc/backuppc/{{ inventory_hostname }}.pl' state=absent
+  file: 
+    path: '/etc/backuppc/{{ inventory_hostname }}.pl'
+    state: absent
   delegate_to: "{{ backuppc_server_name }}"
   when: backup_state is defined and backup_state == 'absent'
   notify: restart backuppc

--- a/tasks/copy_scripts.yml
+++ b/tasks/copy_scripts.yml
@@ -6,8 +6,8 @@
   file:
     path: "{{ backuppc_local_fetch_dir }}/scripts"
     state: directory
-    owner: backuppc
-    group: backuppc
+    owner: "{{ backuppc_client_user }}"
+    group: "{{ backuppc_client_group }}"
     mode: 0766
 
 - name: Copy pre_dump backup script
@@ -15,8 +15,8 @@
   copy:
     src: "{{ playbook_dir }}/host_vars/{{ inventory_hostname }}/files/backuppc/pre_dump.sh"
     dest: "{{ backuppc_local_fetch_dir }}/scripts/pre_dump.sh"
-    owner: backuppc
-    group: backuppc
+    owner: "{{ backuppc_client_user }}"
+    group: "{{ backuppc_client_group }}"
     mode: 0766
 
 - name: Copy post_dump backup script
@@ -24,6 +24,6 @@
   copy:
     src: "{{ playbook_dir }}/host_vars/{{ inventory_hostname }}/files/backuppc/post_dump.sh"
     dest: "{{ backuppc_local_fetch_dir }}/scripts/post_dump.sh"
-    owner: backuppc
-    group: backuppc
+    owner: "{{ backuppc_client_user }}"
+    group: "{{ backuppc_client_group }}"
     mode: 0766

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,12 +6,12 @@
     name: rsync
     state: present
 
-- name: Create the 'backuppc_client_group' group in the client
+- name: Create unix group 'backuppc_client_group' in the client
   group:
     name: "{{ backuppc_client_group }}"
     state: present
 
-- name: Create the 'backuppc_client_user' in the client
+- name: Create unix user 'backuppc_client_user' in the client
   user:
     name: "{{ backuppc_client_user }}"
     home: '{{ backuppc_local_fetch_dir }}'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,24 +6,24 @@
     name: rsync
     state: present
 
-- name: Make sure we have a 'backuppc' group
+- name: Create the 'backuppc_client_group' group in the client
   group:
-    name: backuppc
+    name: "{{ backuppc_client_group }}"
     state: present
 
-- name: Create user
+- name: Create the 'backuppc_client_user' in the client
   user:
-    name: backuppc
+    name: "{{ backuppc_client_user }}"
     home: '{{ backuppc_local_fetch_dir }}'
     shell: /bin/bash
-    groups: backuppc
+    groups: "{{ backuppc_client_group }}"
 
-- name: Create dir
+- name: Create the user's ssh data in the client
   file:
     path: '{{ backuppc_local_fetch_dir }}/.ssh'
     state: directory
-    owner: backuppc
-    group: backuppc
+    owner: "{{ backuppc_client_user }}"
+    group: "{{ backuppc_client_group }}"
     mode: 0700
 
 - name: Define cmnd_alias to allow 'backuppc' privileges
@@ -38,8 +38,8 @@
   lineinfile:
     dest: /etc/sudoers
     state: present
-    regexp: '^%backuppc'
-    line: '%backuppc ALL=(ALL) NOPASSWD: BACKUPS'
+    regexp: '^%{{ backuppc_client_group }}'
+    line: '%{{ backuppc_client_group }} ALL=(ALL) NOPASSWD: BACKUPS'
     validate: 'visudo -cf %s'
 
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,23 @@
 ---
 
 - name: INCLUDE | install rsync and backuppc user
-  include_tasks: install.yml
+  import_tasks: install.yml
   when: backuppc_client
 
 - name: INCLUDE | config user mysql
-  include_tasks: mysql_config.yml
+  import_tasks: mysql_config.yml
   when: backuppc_client and backuppc_db_server_type == 'mysql'
 
 - name: INCLUDE | config PostgreSQL
-  include_tasks: pgsql_config.yml
+  import_tasks: pgsql_config.yml
   when: backuppc_client and backuppc_db_server_type == 'pgsql'
 
 - name: INCLUDE | add file bash
-  include_tasks: copy_scripts.yml
+  import_tasks: copy_scripts.yml
   when: backuppc_client and backuppc_scripts
 
 - name: INCLUDE | Backuppc server configuration
-  include: config.yml
+  import_tasks: config.yml
 
 - name: INCLUDE | SSH to server related configuration
-  include: ssh.yml
+  import_tasks: ssh.yml

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -11,10 +11,9 @@
 
   - name: Add SSH server pub key to client
     authorized_key:
-      user: backuppc
+      user: "{{ backuppc_client_user }}"
       state: present
       key: "{{ cat.stdout }}"
-    delegate_to: "{{ inventory_hostname }}"
   when: backuppc_client
 
 - name: ssh public key of client

--- a/templates/etc/backuppc/_host_config.pl.j2
+++ b/templates/etc/backuppc/_host_config.pl.j2
@@ -10,7 +10,6 @@ $Conf{BackupFilesOnly} = {'*' => [
 {% endfor %}
 	]
 };
-
 {% endif %}
 
 {% if exclude_files is defined %}
@@ -27,6 +26,9 @@ $Conf{BackupFilesExclude} = {
 $Conf{XferMethod} = '{{ xfermethod | default("rsync") }}';
 
 $Conf{ClientCharsetLegacy} = 'utf-8';
+
+$Conf{RsyncClientCmd} = '{{ backuppc_RsyncClientCmd }}';
+$Conf{RsyncClientRestoreCmd} = '{{ backuppc_RsyncClientRestoreCmd }}';
 
 {% if backuppc_scripts is defined and backuppc_scripts %}
 


### PR DESCRIPTION
The commit proposal is operational for the purpose of the issue #2. 

However, it leads me to the following  analysis:  Backuppc proposes a default configuration in a server, thar can be overrride, host per host, parameterper parameter, for different clients. The present proposal leads me to override two (more) values (` $Conf{RsyncClientCmd} ` and ` $Conf{RsyncClientRestoreCmd}`) for _all_ the clients. And this can lead to a not so clean configuration of the server. 

Maybe we should manage flags to say to the role when we want to override these values.