### PR TITLE
Debian 11 compatibility

### DIFF
--- a/tasks/mysql_config.yml
+++ b/tasks/mysql_config.yml
@@ -21,7 +21,7 @@
 
 - name: APT | Install MySQL-Python module
   apt:
-    name: python-mysqldb
+    name: "{{ 'python-mysqldb' if ( ansible_distribution == 'Debian' and ansible_distribution_major_version | int < 11 ) else 'python3-mysqldb' }}"
     state: present
 
 - name: MYSQL_USER | Set backuppc mysql user privileges


### PR DESCRIPTION
For Debian 11, install python3-mysqldb, instead of python3-mysqldb.